### PR TITLE
Fix broken service

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,6 @@ import {
 } from "electron";
 import { join } from "path";
 import { electronApp, optimizer, is } from "@electron-toolkit/utils";
-import icon from "../../resources/icon.png?asset";
 import Store from "electron-store";
 import { View } from "../shared/views";
 import { monitorServiceInputFile } from "./service";
@@ -24,7 +23,6 @@ function createWindow(): void {
     show: false,
     closable: process.platform !== "darwin",
     autoHideMenuBar: true,
-    ...(process.platform === "linux" ? { icon } : {}),
     webPreferences: {
       nodeIntegration: true,
       preload: join(__dirname, "../preload/index.js"),

--- a/src/main/service.ts
+++ b/src/main/service.ts
@@ -10,19 +10,23 @@ function delay(ms: number): Promise<void> {
 
 export async function monitorServiceInputFile() {
   while (true) {
-    if (!fs.existsSync(serviceTempInputFile)) {
-      await delay(100);
-      continue;
-    }
-    const input = fs.readFileSync(serviceTempInputFile, "utf8");
-    console.log("Got service input", input);
-    fs.unlinkSync(serviceTempInputFile);
-    const result = await sendServiceInput(input);
-    if (result == ServiceInvocationCanceledSentinel) {
-      // Just echo the input if canceled so no change happens
-      fs.writeFileSync(serviceTempOutputFile, input);
-    } else {
-      fs.writeFileSync(serviceTempOutputFile, result);
+    try {
+      if (!fs.existsSync(serviceTempInputFile)) {
+        await delay(100);
+        continue;
+      }
+      const input = fs.readFileSync(serviceTempInputFile, "utf8");
+      console.log("Got service input", input);
+      fs.unlinkSync(serviceTempInputFile);
+      const result = await sendServiceInput(input);
+      if (result == ServiceInvocationCanceledSentinel) {
+        // Just echo the input if canceled so no change happens
+        fs.writeFileSync(serviceTempOutputFile, input);
+      } else {
+        fs.writeFileSync(serviceTempOutputFile, result);
+      }
+    } catch (e) {
+      console.error("Error handling service input", e);
     }
   }
 }


### PR DESCRIPTION
I think the service loop was sometimes hitting an error at launch and then stopping. Catching the error seems to fix it. I could only repro this in an actual mac build, not in dev.

Also fixed the build, which was broken because of the main process's attempting to get the icon resource. If we want to use static assets in the main process, we'll have to figure this out, but we don't right now.